### PR TITLE
Changes for moving logics from portal-backend to db-service

### DIFF
--- a/app/auth_group_classes.py
+++ b/app/auth_group_classes.py
@@ -1,11 +1,11 @@
+import requests
 from settings import settings
 from fastapi import HTTPException
-import random
-from router import school, student, user, enrollment_record, grade
-import datetime
 from dateutil.relativedelta import relativedelta
 from request import build_request
 from logger_config import get_logger
+from routes import student_db_url
+from helpers import db_request_token
 
 logger = get_logger()
 
@@ -27,128 +27,44 @@ class EnableStudents:
                 logger.error(f"{param} is required")
                 raise ValueError(f"{param} is required")
 
-        self.grade = data["grade"]
-        self.date_of_birth = data["date_of_birth"]
-        self.gender = data["gender"]
-        self.school_name = data["school_name"]
-        self.category = data["category"]
-        self.first_name = data["first_name"]
-        self.region = data["region"]
-        self.student_id = ""
+        self.data = data
+        self.student_id = self.generate_student_id()
 
-        self.student_id = self.check_if_student_exists()
-
-        if self.student_id == "":
-            counter = COUNTER_FOR_JNV_ID_GENERATION
-
-            while counter > 0:
-                id = (
-                    self.get_class_code()
-                    + self.get_jnv_code()
-                    + self.generate_three_digit_code()
-                )
-
-                if self.check_if_generated_id_already_exists(id):
-                    counter -= 1
-                else:
-                    self.student_id = id
-                    break
-
-            if counter == 0:
-                raise HTTPException(
-                    status_code=400,
-                    detail="JNV Student ID could not be generated. Max loops hit!",
-                )
-
-    def check_if_enrolled_in_school(self, school_id, user_id):
-        enrollment_record_already_exists = enrollment_record.get_enrollment_record(
-            build_request(
-                query_params={
-                    "group_id": school_id,
-                    "group_type": "school",
-                    "user_id": user_id,
-                }
+    def generate_student_id(self):
+        max_retries = 3
+        for attempt in range(max_retries):
+            payload = {
+                "grade": self.data["grade"],
+                "date_of_birth": self.data["date_of_birth"],
+                "gender": self.data["gender"],
+                "school_name": self.data["school_name"],
+                "region": self.data["region"],
+                "category": self.data["category"],
+                "first_name": self.data["first_name"],
+            }
+            response = requests.post(
+                student_db_url + "/generate-id",
+                json=payload,
+                headers=db_request_token(),
             )
-        )
-        return enrollment_record_already_exists
-
-    def check_if_user_exists(self, user_id):
-        user_already_exists = user.get_users(
-            build_request(
-                query_params={
-                    "id": user_id,
-                    "date_of_birth": self.date_of_birth,
-                    "gender": self.gender,
-                    "first_name": self.first_name,
-                }
-            )
-        )
-
-        return user_already_exists
-
-    def check_if_student_exists(self):
-        grade_response = grade.get_grade(
-            build_request(query_params={"number": self.grade})
-        )
-        # First, we check if a student with the same grade and category already exists in the database
-        student_already_exists = student.get_students(
-            build_request(
-                query_params={
-                    "grade_id": grade_response["id"],
-                    "category": self.category,
-                }
-            )
-        )
-
-        if len(student_already_exists) > 0:
-            for existing_student in student_already_exists:
-                # If the student already exists, we check if a user with the same DOB, gender and first_name already exists
-                user_already_exists = self.check_if_user_exists(
-                    existing_student["user"]["id"]
-                )
-
-                if len(user_already_exists) > 0:
-                    # If the student already exists, we check if the student is already enrolled in the given school
-                    school_response = school.get_school(
-                        build_request(query_params={"name": self.school_name})
-                    )
-                    for existing_user in user_already_exists:
-                        enrollment_record_already_exists = (
-                            self.check_if_enrolled_in_school(
-                                school_response["id"], existing_user["id"]
-                            )
+            if response.status_code in [200, 201]:
+                return response.json()["student_id"]
+            else:
+                error_message = response.json().get("error", "Unknown error occurred")
+                logger.error(f"Error generating student ID: {error_message}")
+                if "Max attempts hit" in error_message:
+                    if attempt < max_retries - 1:
+                        logger.error(
+                            f"Retrying... Attempt {attempt + 2} of {max_retries}"
                         )
-                        # At this point, if there is a duplicate student, there should be only one, hence we return the student_id
-                        if len(enrollment_record_already_exists) > 0:
-                            logger.error("Student already exists in the database")
-                            return existing_student["student_id"]
-
+                    else:
+                        logger.error(
+                            "Max retries reached. Unable to generate student ID."
+                        )
+                        break
+                else:
+                    break
         return ""
-
-    def get_class_code(self):
-        graduating_year = datetime.date.today() + relativedelta(
-            years=12 - int(self.grade)
-        )
-        return str(graduating_year.year)[-2:]
-
-    def get_jnv_code(self):
-        school_response = school.get_school(
-            build_request(
-                query_params={"region": self.region, "name": self.school_name}
-            )
-        )
-        return school_response["code"]
-
-    def generate_three_digit_code(self, code=""):
-        for _ in range(3):
-            code += str(random.randint(0, 9))
-        return code
 
     def get_student_id(self):
         return self.student_id
-
-    def check_if_generated_id_already_exists(self, id):
-        student_response = student.get_students(
-            build_request(query_params={"student_id": id})
-        )
-        return len(student_response) != 0

--- a/app/router/group_session.py
+++ b/app/router/group_session.py
@@ -1,48 +1,23 @@
 from fastapi import APIRouter, HTTPException
 import requests
 from settings import settings
-from routes import group_session_db_url, group_db_url, auth_group_db_url
+from routes import group_session_db_url
 from helpers import db_request_token, is_response_valid, is_response_empty
 
 
 router = APIRouter(prefix="/session-group", tags=["Session-Group"])
 
 
-def get_auth_group_details(auth_group_id):
-    auth_group_response = requests.get(
-        auth_group_db_url, params={"id": auth_group_id}, headers=db_request_token()
-    )
-    if is_response_valid(
-        auth_group_response, "Auth group API could not fetch the data!"
-    ):
-        auth_group_data = is_response_empty(
-            auth_group_response.json()[0], True, "Auth group record does not exist!"
-        )
-        return auth_group_data
-
-
-def get_batch_from_group(group_id):
-    response = requests.get(
-        group_db_url, params={"id": group_id}, headers=db_request_token()
-    )
-    if is_response_valid(response, "Group API could not fetch the data!"):
-        batch_data = is_response_empty(
-            response.json()[0], True, "Group record does not exist!"
-        )
-        if batch_data:
-            return get_auth_group_details(batch_data["child_id"]["auth_group_id"])
-
-
 @router.get("/{session_id}")
 def get_group_for_session(session_id: str):
     response = requests.get(
-        group_session_db_url,
+        group_session_db_url + "/session-auth-group",
         params={"session_id": session_id},
         headers=db_request_token(),
     )
     if is_response_valid(response, "Group Session API could not fetch the data!"):
-        group_session_data = is_response_empty(
-            response.json()[0], True, "Group Session record does not exist!"
+        auth_group_data = is_response_empty(
+            response.json(), True, "Auth group data does not exist!"
         )
-        if group_session_data:
-            return get_batch_from_group(group_session_data["group_id"])
+        if auth_group_data:
+            return auth_group_data


### PR DESCRIPTION
## Changes:
### auth_group_classes
- Shifted the logic of checking existing student_id and generating new student_id to the db-service.
- Sending request to the new api endpoint created - student/generate-id
- Added condition: If Max attemps hit then retry by sending request again.

### group_session
- Shifted the logic of getting auth_group for the session_id to db-service.
- Sending request to the new api endpoint created - group-session/session-auth-group