### PR TITLE
Add further identifiers to cookies

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,7 @@ async def error_handling(request: Request, call_next):
 
 origins = [
     "http://localhost:8080",
+    "http://localhost:8081",
     "http://localhost:3000",
     "https://staging-auth.avantifellows.org",
     "https://auth.avantifellows.org",

--- a/app/main.py
+++ b/app/main.py
@@ -67,6 +67,8 @@ origins = [
     "https://auth.avantifellows.org",
     "https://staging-gurukul.avantifellows.org",
     "https://gurukul.avantifellows.org",
+    "https://staging-quiz.avantifellows.org",
+    "https://quiz.avantifellows.org",
 ]
 
 app.add_middleware(

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -129,6 +129,7 @@ authgroup_state_mapping = {
     "PunjabTeachers": "Punjab",
     "TNTeachers": "Tamil Nadu",
     "ChhattisgarhStudents": "Chhattisgarh",
+    "BiharStudents": "Bihar",
 }
 
 # Reverse mapping for state to authgroup lookup

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -43,6 +43,7 @@ SESSION_QUERY_PARAMS = ["id", "name", "session_id"]
 
 STUDENT_QUERY_PARAMS = [
     "student_id",
+    "user_id",
     "apaar_id",
     "grade",
     "grade_id",

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Union, Dict, Optional
+from typing import Union, Dict, Optional, Any
 
 
 class AuthGroupResponse(BaseModel):
@@ -15,7 +15,7 @@ class AuthUser(BaseModel):
     type: str
     name: Optional[str] = None
     is_user_valid: Optional[bool] = None
-    data: Union[Dict[str, str], None]
+    data: Optional[Dict[str, Any]] = None
 
 
 class BatchResponse(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,8 @@ class AuthUser(BaseModel):
     name: Optional[str] = None
     is_user_valid: Optional[bool] = None
     data: Optional[Dict[str, Any]] = None
+    session_mode: Optional[str] = "persistent"
+    audience: Optional[str] = None
 
 
 class BatchResponse(BaseModel):

--- a/app/router/auth.py
+++ b/app/router/auth.py
@@ -40,6 +40,8 @@ def create_access_token(auth_user: AuthUser):
 
     if auth_user.data is None:
         data = {}
+    else:
+        data = {k: v for k, v in auth_user.data.items() if v is not None}
 
     if auth_user.type not in ["user", "organization"]:
         raise HTTPException(
@@ -103,9 +105,11 @@ def refresh_token(payload: dict = Depends(verify_jwt)):
     current_user = payload.get("sub")
 
     # Create custom claims from old token
-    custom_claims = {}
-    if "group" in payload:
-        custom_claims = {"group": payload["group"]}
+    custom_claims = {
+        key: value
+        for key, value in payload.items()
+        if key not in {"sub", "exp", "type", "iat"}
+    }
 
     # Create new access token
     new_payload = {

--- a/app/router/auth.py
+++ b/app/router/auth.py
@@ -9,6 +9,9 @@ router = APIRouter(prefix="/auth", tags=["Authentication"])
 
 # JWT bearer for token extraction
 security = HTTPBearer()
+PERSISTENT_SESSION_MODE = "persistent"
+LAUNCH_SESSION_MODE = "launch"
+ALLOWED_SESSION_MODES = {PERSISTENT_SESSION_MODE, LAUNCH_SESSION_MODE}
 
 
 def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(security)):
@@ -31,17 +34,43 @@ def index():
     return "Portal Authentication!"
 
 
+def _build_access_payload(
+    auth_user: AuthUser, data: dict, expires_in: datetime.timedelta
+) -> dict:
+    payload = {
+        "sub": auth_user.id,
+        "exp": datetime.datetime.utcnow() + expires_in,
+        **data,
+    }
+
+    session_mode = auth_user.session_mode or PERSISTENT_SESSION_MODE
+    payload["session_mode"] = session_mode
+    payload["persist"] = session_mode == PERSISTENT_SESSION_MODE
+
+    if auth_user.audience:
+        payload["aud"] = auth_user.audience
+
+    return payload
+
+
 # if user is valid, generates both access token and refresh token. Otherwise, only an access token.
 @router.post("/create-access-token")
 def create_access_token(auth_user: AuthUser):
     access_token = ""
     refresh_token = ""
     data = auth_user.data
+    session_mode = auth_user.session_mode or PERSISTENT_SESSION_MODE
 
     if auth_user.data is None:
         data = {}
     else:
         data = {k: v for k, v in auth_user.data.items() if v is not None}
+
+    if session_mode not in ALLOWED_SESSION_MODES:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid session_mode. Must be 'persistent' or 'launch'",
+        )
 
     if auth_user.type not in ["user", "organization"]:
         raise HTTPException(
@@ -70,18 +99,19 @@ def create_access_token(auth_user: AuthUser):
                 detail="Data Parameter {} is missing!".format("is_user_valid"),
             )
 
-        # Create access token
-        access_payload = {
-            "sub": auth_user.id,
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(hours=1),
-            **data,
-        }
+        access_expires_in = (
+            datetime.timedelta(minutes=15)
+            if session_mode == LAUNCH_SESSION_MODE
+            else datetime.timedelta(hours=1)
+        )
+
+        access_payload = _build_access_payload(auth_user, data, access_expires_in)
         access_token = jwt.encode(
             access_payload, os.getenv("JWT_SECRET_KEY"), algorithm="HS256"
         )
 
-        # Create refresh token if user is valid
-        if auth_user.is_user_valid:
+        # Create refresh token only for persistent user sessions
+        if auth_user.is_user_valid and session_mode == PERSISTENT_SESSION_MODE:
             refresh_payload = {
                 "sub": auth_user.id,
                 "exp": datetime.datetime.utcnow() + datetime.timedelta(days=30),
@@ -92,7 +122,11 @@ def create_access_token(auth_user: AuthUser):
                 refresh_payload, os.getenv("JWT_SECRET_KEY"), algorithm="HS256"
             )
 
-    return {"access_token": access_token, "refresh_token": refresh_token}
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "session_mode": session_mode,
+    }
 
 
 # generates refresh token

--- a/app/router/auth.py
+++ b/app/router/auth.py
@@ -20,7 +20,10 @@ def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(security)):
     """
     try:
         payload = jwt.decode(
-            credentials.credentials, os.getenv("JWT_SECRET_KEY"), algorithms=["HS256"]
+            credentials.credentials,
+            os.getenv("JWT_SECRET_KEY"),
+            algorithms=["HS256"],
+            options={"verify_aud": False},
         )
         return payload
     except jwt.ExpiredSignatureError:

--- a/app/router/form.py
+++ b/app/router/form.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 from services.form_service import (
     get_form_schema_with_enhancement,
     get_student_fields_for_form,
@@ -39,15 +39,25 @@ async def get_student_fields(request: Request):
     """Get student form fields"""
     query_params = validate_and_build_query_params(
         request.query_params,
-        ["number_of_fields_in_popup_form", "form_id", "student_id"],
+        ["number_of_fields_in_popup_form", "form_id", "student_id", "user_id"],
     )
 
+    student_identifier = query_params.get("user_id") or query_params.get("student_id")
+    identifier_type = "user_id" if query_params.get("user_id") else "student_id"
+
+    if not student_identifier:
+        raise HTTPException(
+            status_code=400,
+            detail="user_id or student_id is required for student form fields",
+        )
+
     logger.info(
-        f"Getting student fields for form: {query_params['form_id']}, student: {query_params['student_id']}"
+        f"Getting student fields for form: {query_params['form_id']}, {identifier_type}: {student_identifier}"
     )
 
     return get_student_fields_for_form(
         query_params["form_id"],
-        query_params["student_id"],
+        student_identifier,
         int(query_params["number_of_fields_in_popup_form"]),
+        identifier_type,
     )

--- a/app/router/user.py
+++ b/app/router/user.py
@@ -87,17 +87,11 @@ async def create_user(request: Request):
                 logger.error("Failed to create student - no response received")
                 raise HTTPException(status_code=500, detail="Failed to create student")
 
-            student_id = create_student_response.get("student_id", "unknown")
             already_exists = create_student_response.get("already_exists", False)
 
-            logger.info(
-                f"Student creation result - ID: {student_id}, Already exists: {already_exists}"
-            )
+            logger.info(f"Student creation result - Already exists: {already_exists}")
 
-            return {
-                "user_id": student_id,
-                "already_exists": already_exists,
-            }
+            return create_student_response
         elif data.get("user_type") == "teacher":
             teacher_data = {
                 "form_data": data["form_data"],
@@ -111,17 +105,11 @@ async def create_user(request: Request):
                 logger.error("Failed to create teacher - no response received")
                 raise HTTPException(status_code=500, detail="Failed to create teacher")
 
-            teacher_id = create_teacher_response.get("teacher_id", "unknown")
             already_exists = create_teacher_response.get("already_exists", False)
 
-            logger.info(
-                f"Teacher creation result - ID: {teacher_id}, Already exists: {already_exists}"
-            )
+            logger.info(f"Teacher creation result - Already exists: {already_exists}")
 
-            return {
-                "user_id": teacher_id,
-                "already_exists": already_exists,
-            }
+            return create_teacher_response
         elif data.get("user_type") == "candidate":
             candidate_data = {
                 "form_data": data["form_data"],
@@ -135,17 +123,11 @@ async def create_user(request: Request):
                     status_code=500, detail="Failed to create candidate"
                 )
 
-            candidate_id = create_candidate_response.get("candidate_id", "unknown")
             already_exists = create_candidate_response.get("already_exists", False)
 
-            logger.info(
-                f"Candidate creation result - ID: {candidate_id}, Already exists: {already_exists}"
-            )
+            logger.info(f"Candidate creation result - Already exists: {already_exists}")
 
-            return {
-                "user_id": candidate_id,
-                "already_exists": already_exists,
-            }
+            return create_candidate_response
         else:
             logger.warning(f"Unsupported user type: {data.get('user_type')}")
             raise HTTPException(status_code=400, detail="Unsupported user type")

--- a/app/router/user_session.py
+++ b/app/router/user_session.py
@@ -36,7 +36,8 @@ class SQSService:
     async def send_message(self, message: AttendanceMessageSchema) -> Dict[str, Any]:
         try:
             response = self.sqs_client.send_message(
-                QueueUrl=self.queue_url, MessageBody=json.dumps([message.dict()])
+                QueueUrl=self.queue_url,
+                MessageBody=json.dumps([message.dict()]),
             )
             print(f"Message sent. MessageId: {response['MessageId']}")
             return {"success": True, "message_id": response["MessageId"]}

--- a/app/services/candidate_service.py
+++ b/app/services/candidate_service.py
@@ -57,7 +57,29 @@ async def verify_candidate_by_id(candidate_id: str, **params) -> bool:
         return bool(candidate_data)
     except Exception as e:
         logger.error(f"Error verifying candidate {candidate_id}: {str(e)}")
-        return False
+    return False
+
+
+def build_candidate_signup_response(
+    candidate_record: Optional[Dict[str, Any]],
+    candidate_id: Optional[str],
+    already_exists: bool,
+) -> Dict[str, Any]:
+    """Build a consistent signup response with canonical identifiers."""
+    user_id = None
+    if isinstance(candidate_record, dict):
+        user_id = candidate_record.get("user_id")
+        user_data = candidate_record.get("user")
+        if user_id is None and isinstance(user_data, dict):
+            user_id = user_data.get("id")
+
+    return {
+        "user_id": str(user_id) if user_id is not None else None,
+        "candidate_id": str(candidate_id) if candidate_id is not None else None,
+        "display_id": str(candidate_id) if candidate_id is not None else None,
+        "display_id_type": "candidate_id" if candidate_id else None,
+        "already_exists": already_exists,
+    }
 
 
 async def create_candidate(request_or_data):
@@ -95,7 +117,10 @@ async def create_candidate(request_or_data):
 
             if candidate_already_exists:
                 logger.info(f"Candidate already exists: {candidate_id}")
-                return {"candidate_id": candidate_id, "already_exists": True}
+                candidate_record = get_candidate_by_id(candidate_id)
+                return build_candidate_signup_response(
+                    candidate_record, candidate_id, True
+                )
 
         # Map subject name to subject_id like grade/grade_id in student.py
         if "subject" in query_params:
@@ -141,7 +166,9 @@ async def create_candidate(request_or_data):
 
         final_candidate_id = query_params.get("candidate_id", "unknown")
         logger.info(f"Successfully created candidate: {final_candidate_id}")
-        return {"candidate_id": final_candidate_id, "already_exists": False}
+        return build_candidate_signup_response(
+            new_candidate_data, final_candidate_id, False
+        )
 
     except HTTPException:
         raise

--- a/app/services/form_service.py
+++ b/app/services/form_service.py
@@ -16,7 +16,7 @@ from services.school_service import (
     get_colleges_list,
     get_dependant_field_mapping_for_auth_group,
 )
-from services.student_service import get_student_by_id
+from services.student_service import get_student_by_id, get_students
 from services.user_service import get_user_by_id
 
 logger = get_logger()
@@ -483,7 +483,10 @@ def find_children_fields(fields: Dict[str, Any], parent_field: Dict[str, Any]) -
 
 
 def get_student_fields_for_form(
-    form_id: str, student_id: str, number_of_fields_in_popup_form: int
+    form_id: str,
+    student_identifier: str,
+    number_of_fields_in_popup_form: int,
+    identifier_type: str = "student_id",
 ) -> Dict[int, Any]:
     """Get student fields for form"""
 
@@ -492,7 +495,10 @@ def get_student_fields_for_form(
         logger.error(f"Form not found with ID: {form_id}")
         return {}
 
-    student_response = get_student_by_id(student_id)
+    if identifier_type == "user_id":
+        student_response = get_students(user_id=student_identifier)
+    else:
+        student_response = get_student_by_id(student_identifier)
     student_data = (
         student_response[0] if student_response and len(student_response) > 0 else {}
     )

--- a/app/services/school_service.py
+++ b/app/services/school_service.py
@@ -233,7 +233,7 @@ def get_districts_by_filters(
             schools_data = [schools_data]
 
         districts = []
-        chhattisgarh_districts = "Bastar+Dhamtari+Durg+Gariaband+Janjgir - Champa+Jashpur+Raigarh+Raipur+Rajnandgaon".split(
+        chhattisgarh_districts = "Bastar+DANTEWADA+Dhamtari+Durg+Gariaband+Janjgir - Champa+Jashpur+Raigarh+Raipur+Rajnandgaon".split(
             "+"
         )
         maharashtra_districts = ["Gadchiroli", "Bhandara"]

--- a/app/services/school_service.py
+++ b/app/services/school_service.py
@@ -237,6 +237,7 @@ def get_districts_by_filters(
             "+"
         )
         maharashtra_districts = ["Gadchiroli", "Bhandara"]
+        bihar_districts = ["Begusarai"]
         for school in schools_data:
             if school.get("district"):
                 if auth_group == "PunjabTeachers":
@@ -247,6 +248,9 @@ def get_districts_by_filters(
                         districts.append(school.get("district"))  # change later
                 elif auth_group == "MaharashtraStudents":
                     if school.get("district") in maharashtra_districts:
+                        districts.append(school.get("district"))  # change later
+                elif auth_group == "BiharStudents":
+                    if school.get("district") in bihar_districts:
                         districts.append(school.get("district"))  # change later
                 else:
                     districts.append(school.get("district"))
@@ -395,6 +399,7 @@ def get_dependant_field_mapping_for_auth_group(
         "+"
     )
     maharashtra_districts = ["Gadchiroli", "Bhandara"]
+    bihar_districts = ["Begusarai"]
     for school in schools_data:
         if school.get("district"):
             if auth_group == "PunjabTeachers":
@@ -405,6 +410,9 @@ def get_dependant_field_mapping_for_auth_group(
                     filtered_schools.append(school)
             elif auth_group == "MaharashtraStudents":
                 if school.get("district") in maharashtra_districts:
+                    filtered_schools.append(school)
+            elif auth_group == "BiharStudents":
+                if school.get("district") in bihar_districts:
                     filtered_schools.append(school)
             else:
                 filtered_schools.append(school)

--- a/app/services/school_service.py
+++ b/app/services/school_service.py
@@ -140,9 +140,12 @@ def get_states_list() -> Dict[str, Any]:
     return {"states": states}
 
 
-async def verify_school_comprehensive(code: str, query_params: Dict[str, Any]) -> bool:
-    """Comprehensive school verification with fallback logic."""
+async def verify_school_comprehensive(
+    code: str, query_params: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Comprehensive school verification returning canonical identifiers."""
     logger.info(f"Verifying school with code: {code} and params: {query_params}")
+    invalid_response = {"is_valid": False}
 
     # Try school code first
     school_record = None
@@ -181,7 +184,7 @@ async def verify_school_comprehensive(code: str, query_params: Dict[str, Any]) -
 
     if not school_record:
         logger.warning(f"No school found for code: {code}")
-        return False
+        return invalid_response
 
     # Verify all query parameters
     for key, value in query_params.items():
@@ -189,10 +192,10 @@ async def verify_school_comprehensive(code: str, query_params: Dict[str, Any]) -
             user_data = school_record.get("user", {})
             if not isinstance(user_data, dict):
                 logger.warning(f"Invalid user data structure for school code: {code}")
-                return False
+                return invalid_response
             if user_data.get(key) != value:
                 logger.info(f"User verification failed for key: {key}")
-                return False
+                return invalid_response
 
         elif key in SCHOOL_QUERY_PARAMS:
             if key == "code" and found_via_udise_code:
@@ -200,10 +203,29 @@ async def verify_school_comprehensive(code: str, query_params: Dict[str, Any]) -
                 continue
             if school_record.get(key) != value:
                 logger.info(f"School verification failed for key: {key}")
-                return False
+                return invalid_response
 
     logger.info(f"School verification successful for code: {code}")
-    return True
+    identifiers: Dict[str, Any] = {
+        "user_id": None,
+        "display_id": None,
+        "display_id_type": "school_code",
+        "school_code": None,
+    }
+
+    school_code = school_record.get("code") or code
+    if school_code is not None:
+        identifiers["display_id"] = str(school_code)
+        identifiers["school_code"] = str(school_code)
+
+    user_data = school_record.get("user", {})
+    if isinstance(user_data, dict):
+        user_pk = user_data.get("id")
+        if user_pk is not None:
+            identifiers["user_id"] = str(user_pk)
+
+    identifiers = {k: v for k, v in identifiers.items() if v is not None}
+    return {"is_valid": True, **identifiers}
 
 
 def get_districts_by_filters(

--- a/app/services/student_service.py
+++ b/app/services/student_service.py
@@ -545,6 +545,7 @@ async def create_student(request_or_data):
                 "AllIndiaStudents",
                 "ChhattisgarhStudents",
                 "MaharashtraStudents",
+                "BiharStudents",
             ]:
                 phone = query_params.get("phone")
                 if not phone:

--- a/app/services/student_service.py
+++ b/app/services/student_service.py
@@ -76,7 +76,52 @@ async def verify_student_by_id(student_id: str, **params) -> bool:
         )
     except Exception as e:
         logger.error(f"Error verifying student {student_id}: {str(e)}")
-        return False
+    return False
+
+
+def normalize_student_record(student_response: Any) -> Dict[str, Any]:
+    """Normalize student response into a single dict record."""
+    if isinstance(student_response, list):
+        return student_response[0] if len(student_response) > 0 else {}
+    if isinstance(student_response, dict):
+        return student_response
+    return {}
+
+
+def build_student_signup_response(
+    student_record: Dict[str, Any], student_id: Optional[str], already_exists: bool
+) -> Dict[str, Any]:
+    """Build a consistent signup response with canonical identifiers."""
+    apaar_id = None
+    user_id = None
+    resolved_student_id = student_id
+
+    if isinstance(student_record, dict):
+        if not resolved_student_id:
+            resolved_student_id = student_record.get("student_id")
+        apaar_id = student_record.get("apaar_id")
+        user_id = student_record.get("user_id")
+        user_data = student_record.get("user")
+        if user_id is None and isinstance(user_data, dict):
+            user_id = user_data.get("id")
+
+    display_id = resolved_student_id or apaar_id
+    display_id_type = None
+    if resolved_student_id:
+        display_id_type = "student_id"
+    elif apaar_id:
+        display_id_type = "apaar_id"
+
+    return {
+        "user_id": str(user_id) if user_id is not None else None,
+        "student_id": (
+            str(resolved_student_id) if resolved_student_id is not None else None
+        ),
+        "apaar_id": str(apaar_id) if apaar_id is not None else None,
+        "display_id": str(display_id) if display_id is not None else None,
+        "display_id_type": display_id_type,
+        "already_exists": already_exists,
+    }
 
 
 async def update_student_data(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -439,20 +484,34 @@ async def complete_profile_details_service(
 ) -> Optional[Dict[str, Any]]:
     """Complete profile details - business logic."""
     try:
+        student_identifier = data.get("user_id") or data.get("student_id")
+        identifier_type = "user_id" if data.get("user_id") else "student_id"
+
         logger.info(
-            f"Completing profile details for student: {data.get('student_id', 'unknown')}"
+            f"Completing profile details for student ({identifier_type}): {student_identifier}"
         )
+
+        if not student_identifier:
+            raise HTTPException(
+                status_code=400,
+                detail="user_id or student_id is required to complete profile details",
+            )
 
         student_data = build_student_and_user_data(data)
 
-        student_response = get_student_by_id(data["student_id"])
+        if identifier_type == "user_id":
+            student_response = get_students(user_id=student_identifier)
+        else:
+            student_response = get_student_by_id(student_identifier)
 
         if (
             not student_response
             or not isinstance(student_response, list)
             or len(student_response) == 0
         ):
-            logger.error(f"Student not found for ID: {data.get('student_id')}")
+            logger.error(
+                f"Student not found for {identifier_type}: {student_identifier}"
+            )
             raise HTTPException(status_code=404, detail="Student not found")
 
         # Safe access to first student
@@ -465,6 +524,8 @@ async def complete_profile_details_service(
         # Remove student_id from patch data as it's an identifier, not an updatable field
         if "student_id" in student_data:
             del student_data["student_id"]
+        if "user_id" in student_data:
+            del student_data["user_id"]
         result = await update_student_data(student_data)
 
         logger.info("Successfully completed profile details")
@@ -533,16 +594,14 @@ async def create_student(request_or_data):
                 raise HTTPException(status_code=400, detail="Student ID is required")
 
             if await verify_student_by_id(student_id):
-                return {"student_id": student_id, "already_exists": True}
+                student_record = normalize_student_record(get_student_by_id(student_id))
+                return build_student_signup_response(student_record, student_id, True)
         else:
             if data["auth_group"] == "EnableStudents":
                 student_id = EnableStudents(query_params).get_student_id()
                 query_params["student_id"] = student_id
                 if student_id == "":
-                    return {
-                        "student_id": query_params["student_id"],
-                        "already_exists": True,
-                    }
+                    return build_student_signup_response({}, student_id, True)
             elif data["auth_group"] in [
                 "FeedingIndiaStudents",
                 "UttarakhandStudents",
@@ -561,7 +620,8 @@ async def create_student(request_or_data):
                     )
                 query_params["student_id"] = phone
                 if await verify_student_by_id(phone):
-                    return {"student_id": phone, "already_exists": True}
+                    student_record = normalize_student_record(get_student_by_id(phone))
+                    return build_student_signup_response(student_record, phone, True)
             else:
                 if not (query_params.get("email") or query_params.get("phone")):
                     raise HTTPException(
@@ -570,10 +630,22 @@ async def create_student(request_or_data):
                 if get_user_by_email_and_phone(
                     email=query_params.get("email"), phone=query_params.get("phone")
                 ):
-                    return {
-                        "student_id": query_params.get("student_id", "unknown"),
-                        "already_exists": True,
-                    }
+                    existing_user = get_user_by_email_and_phone(
+                        email=query_params.get("email"),
+                        phone=query_params.get("phone"),
+                    )
+                    student_record = {}
+                    if isinstance(existing_user, dict):
+                        user_id = existing_user.get("id")
+                        if user_id is not None:
+                            student_record = normalize_student_record(
+                                get_students(user_id=user_id)
+                            )
+                    return build_student_signup_response(
+                        student_record,
+                        query_params.get("student_id"),
+                        True,
+                    )
 
         # Process grade
         if "grade" in query_params:
@@ -665,7 +737,8 @@ async def create_student(request_or_data):
 
         final_student_id = query_params.get("student_id", "unknown")
         logger.info(f"Successfully created student: {final_student_id}")
-        return {"student_id": final_student_id, "already_exists": False}
+        student_record = normalize_student_record(new_student_data)
+        return build_student_signup_response(student_record, final_student_id, False)
 
     except HTTPException:
         raise

--- a/app/services/teacher_service.py
+++ b/app/services/teacher_service.py
@@ -56,7 +56,29 @@ async def verify_teacher_by_id(teacher_id: str, **params) -> bool:
         return bool(teacher_data)
     except Exception as e:
         logger.error(f"Error verifying teacher {teacher_id}: {str(e)}")
-        return False
+    return False
+
+
+def build_teacher_signup_response(
+    teacher_record: Optional[Dict[str, Any]],
+    teacher_id: Optional[str],
+    already_exists: bool,
+) -> Dict[str, Any]:
+    """Build a consistent signup response with canonical identifiers."""
+    user_id = None
+    if isinstance(teacher_record, dict):
+        user_id = teacher_record.get("user_id")
+        user_data = teacher_record.get("user")
+        if user_id is None and isinstance(user_data, dict):
+            user_id = user_data.get("id")
+
+    return {
+        "user_id": str(user_id) if user_id is not None else None,
+        "teacher_id": str(teacher_id) if teacher_id is not None else None,
+        "display_id": str(teacher_id) if teacher_id is not None else None,
+        "display_id_type": "teacher_id" if teacher_id else None,
+        "already_exists": already_exists,
+    }
 
 
 async def create_teacher(request_or_data):
@@ -96,7 +118,8 @@ async def create_teacher(request_or_data):
 
             if teacher_already_exists:
                 logger.info(f"Teacher already exists: {teacher_id}")
-                return {"teacher_id": teacher_id, "already_exists": True}
+                teacher_record = get_teacher_by_id(teacher_id)
+                return build_teacher_signup_response(teacher_record, teacher_id, True)
 
             query_params["is_af_teacher"] = False  # PunjabTeachers are not AF teachers
 
@@ -149,7 +172,7 @@ async def create_teacher(request_or_data):
 
         final_teacher_id = query_params.get("teacher_id", "unknown")
         logger.info(f"Successfully created teacher: {final_teacher_id}")
-        return {"teacher_id": final_teacher_id, "already_exists": False}
+        return build_teacher_signup_response(new_teacher_data, final_teacher_id, False)
 
     except HTTPException:
         raise


### PR DESCRIPTION
## Summary
- add launch-token aware auth payloads so portal can distinguish persistent Gurukul sessions from short-lived quiz/report launch sessions
- normalize student, teacher, candidate, and school identity payloads around canonical `user_id` plus display identifiers
- keep portal-backend as the source of truth for the richer identity bundle used downstream
- allow launch tokens with audience claims through `/auth/verify`

## Current status
- Branch refreshed with latest `origin/main` on 2026-04-29.
- Latest main merge brought in current form/school/subject service changes cleanly.

## Rationale
Quiz and reporting flows should stop depending on editable URL `userId` values or on long-lived shared cookies. Portal should mint short-lived launch context for those apps, while Gurukul can continue to use a persistent session.

## Assumptions
- persistent auth remains valid for Gurukul-style sessions
- quiz/report launches use short-lived launch tokens without refresh-token flow
- school identities should follow the same canonical `user_id`/`display_id` pattern as student, teacher, and candidate

## Major files to review
- `app/router/auth.py`
- `app/models.py`
- `app/services/school_service.py`
- `app/services/form_service.py`
- `app/services/subject_service.py`

## Follow-up validation
- student, teacher, candidate, and school verification responses
- Gurukul persistent-token flow
- quiz/report launch-token verification
