### PR TITLE
fix(auth): raise HTTPException in create-access-token (#60)

### DIFF
--- a/app/router/auth.py
+++ b/app/router/auth.py
@@ -48,7 +48,7 @@ def create_access_token(auth_user: AuthUser):
 
     if auth_user.type == "organization":
         if not auth_user.name:
-            return HTTPException(
+            raise HTTPException(
                 status_code=400, detail="Data Parameter {} is missing!".format("name")
             )
         expires = datetime.timedelta(weeks=260)
@@ -63,7 +63,7 @@ def create_access_token(auth_user: AuthUser):
 
     elif auth_user.type == "user":
         if "is_user_valid" not in auth_user.dict().keys():
-            return HTTPException(
+            raise HTTPException(
                 status_code=400,
                 detail="Data Parameter {} is missing!".format("is_user_valid"),
             )


### PR DESCRIPTION
Re-submitting on @pritamps's [invitation](https://github.com/avantifellows/portal-backend/pull/73#issuecomment-3865979082) after PR #73 was closed on 2026-02-08 for age.

## What

In `app/router/auth.py::create_access_token`, the missing-name (for organization) and missing-is_user_valid (for user) branches use ``return HTTPException(...)`` instead of ``raise``. This returns the exception *object* as the 200 response body rather than triggering FastAPI's error handling — the client gets a success status with a serialized exception payload instead of the intended 400.

## Fix

Two-line change: ``return HTTPException(...)`` → ``raise HTTPException(...)`` at both call sites.

## Scope vs #60

Issue #60 originally flagged both (a) missing handling for invalid ``type`` values and (b) the error-path bug. Since #73 was opened, upstream already added ``if auth_user.type not in ["user", "organization"]: raise HTTPException(...)`` at the top of the function, which covers (a). This PR is scoped down to (b) only.

Rebased onto current ``main``.