### PR TITLE
chore(student): remove family_income mapping

### DIFF
--- a/app/mapping.py
+++ b/app/mapping.py
@@ -55,7 +55,6 @@ STUDENT_QUERY_PARAMS = [
     "stream",
     "board_stream",
     "planned_competitive_exams",
-    "family_income",
     "father_profession",
     "father_education_level",
     "mother_profession",


### PR DESCRIPTION
## Summary

- Remove the obsolete `student.family_income` field from portal-backend's student query/form mapping
- Keep `annual_family_income` in the mapping for existing form schemas and db-service payloads

## Context

Companion cleanup for avantifellows/db-service#532, which drops `student.family_income` while keeping `annual_family_income`.

## Testing

- `python -c 'import sys; sys.path.insert(0, "app"); from mapping import STUDENT_QUERY_PARAMS; assert "family_income" not in STUDENT_QUERY_PARAMS; assert "annual_family_income" in STUDENT_QUERY_PARAMS; print("mapping ok")'`
- pre-commit hooks on commit: trim trailing whitespace, end-of-file fixer, merge conflict check, large file check, black, flake8