### PR TITLE
fix(student): verify login against all auth-group candidates

### DIFF
--- a/app/services/student_service.py
+++ b/app/services/student_service.py
@@ -10,7 +10,6 @@ from helpers import (
     db_request_token,
     is_response_valid,
     is_response_empty,
-    safe_get_first_item,
 )
 from mapping import (
     STUDENT_QUERY_PARAMS,
@@ -423,11 +422,102 @@ def check_if_student_id_is_part_of_request(query_params: Dict[str, Any]) -> None
         )
 
 
+def _fetch_student_candidates(**params) -> list:
+    """Fetch student records for a lookup, always returned as a list of candidates.
+
+    `student_id` is only unique within an auth group, so a lookup can legitimately
+    match several records. Callers must evaluate every candidate rather than assuming
+    the first one is the right student.
+    """
+    response = requests.get(
+        student_db_url,
+        params={k: v for k, v in params.items() if v is not None},
+        headers=db_request_token(),
+    )
+
+    if not is_response_valid(response):
+        return []
+
+    student_data = is_response_empty(response.json(), False)
+    if not student_data:
+        return []
+
+    if isinstance(student_data, list):
+        return [record for record in student_data if isinstance(record, dict)]
+    if isinstance(student_data, dict):
+        return [student_data]
+    return []
+
+
+def _matches_verification_params(
+    student_record: Dict[str, Any],
+    query_params: Dict[str, Any],
+    skip_student_id_check: bool,
+) -> bool:
+    """Check a single student record against every supplied verification param."""
+    student_id = query_params.get("student_id")
+
+    for key, value in query_params.items():
+        if key in USER_QUERY_PARAMS:
+            user_data = student_record.get("user", {})
+            if not isinstance(user_data, dict):
+                logger.warning(f"Invalid user data structure for student: {student_id}")
+                return False
+            if user_data.get(key) != value:
+                logger.info(f"User verification failed for key: {key}")
+                return False
+
+        elif key in STUDENT_QUERY_PARAMS:
+            # Skip student_id verification if we found the student via apaar_id or phone
+            if key == "student_id" and skip_student_id_check:
+                logger.info(
+                    "Skipping student_id verification - found via alternative method"
+                )
+                continue
+            if student_record.get(key) != value:
+                logger.info(f"Student verification failed for key: {key}")
+                return False
+
+        elif key == "auth_group_id":
+            # Verify user belongs to the auth group
+            group_response = get_group_by_child_id_and_type(
+                child_id=value, group_type="auth_group"
+            )
+
+            if not (
+                group_response
+                and isinstance(group_response, dict)
+                and "id" in group_response
+            ):
+                logger.warning(f"Group not found for auth_group_id: {value}")
+                return False
+
+            user_data = student_record.get("user", {})
+            if not (isinstance(user_data, dict) and "id" in user_data):
+                logger.warning("Invalid user data in student record")
+                return False
+
+            group_user_response = get_group_user(
+                group_id=group_response["id"], user_id=user_data["id"]
+            )
+            if not group_user_response or group_user_response == []:
+                logger.info("User not found in auth group")
+                return False
+
+    return True
+
+
 async def verify_student_comprehensive(query_params: Dict[str, Any]) -> Dict[str, Any]:
     """Comprehensive student verification with multiple fallback methods.
 
     Returns a payload containing verification status and core identifiers so that
     clients don't have to re-fetch the student record after validation.
+
+    A `student_id` is only unique within an auth group, so the same `student_id` can
+    resolve to several student records (one per auth group). Every candidate is checked
+    and the first one satisfying all verification params wins — otherwise a student
+    registered in multiple auth groups could only ever log into whichever record
+    db-service happened to return first.
     """
     student_id = query_params.get("student_id")
     phone = query_params.get("phone")
@@ -451,122 +541,45 @@ async def verify_student_comprehensive(query_params: Dict[str, Any]) -> Dict[str
             "Detected EnableStudents auth group - will try apaar_id fallback if needed"
         )
 
-    student_record = None
-
-    # Try student_id first
-    response = requests.get(
-        student_db_url,
-        params={"student_id": student_id},
-        headers=db_request_token(),
-    )
-
-    if is_response_valid(response):
-        student_data = is_response_empty(response.json(), False)
-        if student_data:
-            student_record = (
-                safe_get_first_item(student_data)
-                if isinstance(student_data, list)
-                else student_data
-            )
+    # Each lookup strategy yields candidates plus whether a student_id equality check
+    # still applies (it doesn't when the student was located via apaar_id or phone).
+    candidates = [
+        (record, False) for record in _fetch_student_candidates(student_id=student_id)
+    ]
 
     # For EnableStudents: if no student found with student_id, try apaar_id
-    found_via_apaar_id = False
-    if not student_record and is_enable_students:
+    if not candidates and is_enable_students:
         logger.info(f"EnableStudents: Trying apaar_id for: {student_id}")
-
-        response = requests.get(
-            student_db_url,
-            params={"apaar_id": student_id},
-            headers=db_request_token(),
-        )
-
-        if is_response_valid(response):
-            student_data = is_response_empty(response.json(), False)
-            if student_data:
-                student_record = (
-                    safe_get_first_item(student_data)
-                    if isinstance(student_data, list)
-                    else student_data
-                )
-                found_via_apaar_id = True
+        candidates = [
+            (record, True) for record in _fetch_student_candidates(apaar_id=student_id)
+        ]
 
     # If still no student found and we have phone, try searching by phone
-    found_via_phone = False
-    if not student_record and phone and phone != student_id:
+    if not candidates and phone and phone != student_id:
         logger.info(f"Trying phone search for: {phone}")
+        candidates = [
+            (record, True) for record in _fetch_student_candidates(phone=phone)
+        ]
 
-        response = requests.get(
-            student_db_url,
-            params={"phone": phone},
-            headers=db_request_token(),
-        )
-
-        if is_response_valid(response):
-            student_data = is_response_empty(response.json(), False)
-            if student_data:
-                student_record = (
-                    safe_get_first_item(student_data)
-                    if isinstance(student_data, list)
-                    else student_data
-                )
-                found_via_phone = True
-
-    if not student_record:
+    if not candidates:
         logger.warning(f"No student found for: {student_id}")
         return invalid_response
 
-    # Verify all query parameters
-    for key, value in query_params.items():
-        if key in USER_QUERY_PARAMS:
-            user_data = student_record.get("user", {})
-            if not isinstance(user_data, dict):
-                logger.warning(f"Invalid user data structure for student: {student_id}")
-                return invalid_response
-            if user_data.get(key) != value:
-                logger.info(f"User verification failed for key: {key}")
-                return invalid_response
+    if len(candidates) > 1:
+        logger.info(
+            f"Found {len(candidates)} student records for {student_id} - "
+            "checking each against verification params"
+        )
 
-        elif key in STUDENT_QUERY_PARAMS:
-            # Skip student_id verification if we found the student via apaar_id or phone
-            if key == "student_id" and (found_via_apaar_id or found_via_phone):
-                logger.info(
-                    "Skipping student_id verification - found via alternative method"
-                )
-                continue
-            if student_record.get(key) != value:
-                logger.info(f"Student verification failed for key: {key}")
-                return invalid_response
+    student_record = None
+    for candidate, skip_student_id_check in candidates:
+        if _matches_verification_params(candidate, query_params, skip_student_id_check):
+            student_record = candidate
+            break
 
-        elif key == "auth_group_id":
-            # Verify user belongs to the auth group
-            group_response = get_group_by_child_id_and_type(
-                child_id=value, group_type="auth_group"
-            )
-
-            if not (
-                group_response
-                and isinstance(group_response, dict)
-                and "id" in group_response
-            ):
-                logger.warning(f"Group not found for auth_group_id: {value}")
-                return invalid_response
-
-            group_record = group_response
-            if not (isinstance(group_record, dict) and "id" in group_record):
-                logger.warning("Invalid group record structure")
-                return invalid_response
-
-            user_data = student_record.get("user", {})
-            if not (isinstance(user_data, dict) and "id" in user_data):
-                logger.warning("Invalid user data in student record")
-                return invalid_response
-
-            group_user_response = get_group_user(
-                group_id=group_record["id"], user_id=user_data["id"]
-            )
-            if not group_user_response or group_user_response == []:
-                logger.info("User not found in auth group")
-                return invalid_response
+    if student_record is None:
+        logger.info(f"No student record satisfied verification for: {student_id}")
+        return invalid_response
 
     identifiers = {
         "student_id": student_record.get("student_id"),


### PR DESCRIPTION
## Why

Follow-up to #88. That PR correctly scoped the student **write** path to `(student_id, auth_group)`, but the **read/login** path was left globally first-match — so the two halves are now inconsistent.

Because `student_id` is only unique within an auth group, the same `student_id` can legitimately resolve to **several** student records, one per auth group. `verify_student_comprehensive` collapsed the db-service response with `safe_get_first_item` and validated only that first record:

```python
response = requests.get(student_db_url, params={"student_id": student_id}, ...)
student_record = safe_get_first_item(student_data) if isinstance(student_data, list) else student_data
```

The `auth_group_id` check then ran `get_group_user(...)` against **only that first record's** user. If the student's membership in the requested auth group lived on a *different* record, verification returned `is_valid: False` and the student saw **"Student ID is not registered"** — despite the mapping existing.

This is by design on the db-service side: the same `student_id` in two or more auth groups is now **supported and expected**, with one student record per auth group. The gap is that portal-backend's read path never caught up — it still assumes a `student_id` resolves to exactly one record. So the more students legitimately register across auth groups, the more often login breaks.

### Reported case

Student `8979364564` (Uttarakhand) could log into `AllIndiaStudents` but not `UttarakhandStudents`. Production has two records for that `student_id` — which is the correct, supported shape:

| student.id | user_id | auth group | batch |
|---|---|---|---|
| 490965 | 500009 | AllIndiaStudents | `AllIndiaStudents_11_24_A001` |
| 519352 | 529877 | UttarakhandStudents | `UttarakhandStudents_TP_2028_common_A001` |

db-service returns `490965` (user `500009`) first. That user has **zero** membership in the UttarakhandStudents group, so Uttarakhand login always failed. AllIndiaStudents worked only by accident of ordering.

## What

- Add `_fetch_student_candidates(**params)` — returns **every** matching record instead of silently discarding all but the first.
- Extract the per-record checks into `_matches_verification_params(...)`, preserving existing semantics (including skipping the `student_id` equality check when the student was located via `apaar_id`/`phone`).
- Iterate all candidates and accept the first satisfying **every** verification param, including the `auth_group_id` → `group_user` check.
- Log when more than one candidate is found, to make these multi-auth-group students visible in logs.

The returned `user_id`/`student_id`/`apaar_id` identifiers now come from the record that actually matched, so downstream consumers (e.g. `GET /form/student`, which prefers `user_id`) get the right student's profile rather than the wrong auth group's.

## Verification

Simulated old vs. new against **live production** data for `8979364564`:

```
db-service returned 2 candidates for student_id=8979364564
   student.id=490965 user_id=500009
   student.id=519352 user_id=529877

UttarakhandStudents (auth_group_id=5, group_id=5656):
   OLD (first-match only) -> is_valid=False
   NEW (check all)        -> is_valid=True  resolved user_id=529877
AllIndiaStudents (auth_group_id=20, group_id=8730):
   OLD (first-match only) -> is_valid=True
   NEW (check all)        -> is_valid=True  resolved user_id=500009
```

The reported failure flips to passing, and the previously-working auth group is unaffected.

Single-record students take the exact same path as before (one candidate, same checks), so this is a strict widening — no lookup that previously succeeded can now fail.

`black` and `flake8` pass via pre-commit.

## Notes

- No db-service change needed; this is portal-backend only.
- **The two records for `8979364564` are correct data, not duplicates to clean up.** db-service now intentionally allows the same `student_id` across two or more auth groups — one student record per auth group, each with its own batch/grade/school enrollments. No data migration or merge is wanted here; the records should stay as they are. The defect was purely that portal-backend's read path still assumed a `student_id` could only ever resolve to one record.
- Remaining first-match readers, tracked separately (not reachable from the current portal-frontend, which passes `user_id`): `services/form_service.py:541` and `services/student_service.py:627` both take `[0]` of an unscoped `student_id` lookup. The latter is a write path (`complete_profile_details_service`), so it deserves its own review. `GET /student/` (`router/student.py:37`) also doesn't accept an `auth_group` filter yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
