### PR TITLE
fix(student): scope remaining student reads by auth_group

### DIFF
--- a/app/router/form.py
+++ b/app/router/form.py
@@ -39,7 +39,15 @@ async def get_student_fields(request: Request):
     """Get student form fields"""
     query_params = validate_and_build_query_params(
         request.query_params,
-        ["number_of_fields_in_popup_form", "form_id", "student_id", "user_id"],
+        [
+            "number_of_fields_in_popup_form",
+            "form_id",
+            "student_id",
+            "user_id",
+            # `student_id` is only unique within an auth group, so callers that only
+            # have a student_id can pass auth_group to select the right student.
+            "auth_group",
+        ],
     )
 
     student_identifier = query_params.get("user_id") or query_params.get("student_id")
@@ -60,4 +68,5 @@ async def get_student_fields(request: Request):
         student_identifier,
         int(query_params["number_of_fields_in_popup_form"]),
         identifier_type,
+        auth_group=query_params.get("auth_group"),
     )

--- a/app/router/student.py
+++ b/app/router/student.py
@@ -28,7 +28,10 @@ logger = get_logger()
 def get_students(request: Request):
     query_params = validate_and_build_query_params(
         request.query_params,
-        STUDENT_QUERY_PARAMS + USER_QUERY_PARAMS + ENROLLMENT_RECORD_PARAMS,
+        STUDENT_QUERY_PARAMS + USER_QUERY_PARAMS + ENROLLMENT_RECORD_PARAMS
+        # `student_id` is only unique within an auth group; db-service scopes the lookup
+        # to the matching auth_group enrollment record when either of these is supplied.
+        + ["auth_group", "auth_group_id"],
     )
 
     logger.info(f"Fetching students with params: {query_params}")

--- a/app/services/form_service.py
+++ b/app/services/form_service.py
@@ -17,7 +17,11 @@ from services.school_service import (
     get_districts_by_filters,
     get_dependant_field_mapping_for_auth_group,
 )
-from services.student_service import get_student_by_id, get_students
+from services.student_service import (
+    get_student_by_id,
+    get_students,
+    select_student_record,
+)
 from services.user_service import get_user_by_id
 
 logger = get_logger()
@@ -527,6 +531,7 @@ def get_student_fields_for_form(
     student_identifier: str,
     number_of_fields_in_popup_form: int,
     identifier_type: str = "student_id",
+    auth_group: Optional[str] = None,
 ) -> Dict[int, Any]:
     """Get student fields for form"""
 
@@ -535,12 +540,22 @@ def get_student_fields_for_form(
         logger.error(f"Form not found with ID: {form_id}")
         return {}
 
+    # Scope by auth_group whenever the caller supplied one, on both branches. A real
+    # user_id is globally unique and needs no scoping, but callers have been known to put
+    # a student_id in the user_id slot, so scoping defensively costs nothing and stops a
+    # mislabelled identifier from resolving to another auth group's student.
     if identifier_type == "user_id":
-        student_response = get_students(user_id=student_identifier)
+        student_response = get_students(
+            user_id=student_identifier, auth_group=auth_group
+        )
     else:
-        student_response = get_student_by_id(student_identifier)
-    student_data = (
-        student_response[0] if student_response and len(student_response) > 0 else {}
+        # `student_id` is only unique within an auth group.
+        student_response = get_student_by_id(student_identifier, auth_group=auth_group)
+
+    student_data = select_student_record(
+        student_response,
+        identifier=str(student_identifier),
+        auth_group=auth_group,
     )
 
     if isinstance(student_data, dict) and not isinstance(

--- a/app/services/student_service.py
+++ b/app/services/student_service.py
@@ -171,6 +171,52 @@ def get_student_by_id(
     return get_students(apaar_id=student_id, auth_group=auth_group)
 
 
+def select_student_record(
+    student_response: Any,
+    identifier: Optional[str] = None,
+    auth_group: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Pick a single student record from a lookup that may match several records.
+
+    `student_id` is no longer globally unique (db-service dropped the global unique
+    index), so a `student_id` lookup can legitimately return one record per auth group.
+    When the caller could not scope the lookup we mirror db-service's tie-break -
+    lowest `id` first, matching its `order_by: [asc: s.id], limit: 1` - so portal and
+    db-service resolve the same student instead of disagreeing on ordering.
+    """
+    records = (
+        [record for record in student_response if isinstance(record, dict)]
+        if isinstance(student_response, list)
+        else [student_response] if isinstance(student_response, dict) else []
+    )
+
+    if not records:
+        return {}
+
+    if len(records) > 1:
+        if auth_group:
+            # Scoped lookups should already be unambiguous; surface it if they aren't.
+            logger.warning(
+                f"{len(records)} student records matched {identifier} even when scoped "
+                f"to auth_group {auth_group}"
+            )
+        else:
+            logger.warning(
+                f"{len(records)} student records matched {identifier} across auth "
+                "groups; resolving by lowest id. Pass auth_group (or user_id) to "
+                "select a specific student."
+            )
+        records = sorted(
+            records,
+            key=lambda record: (
+                record.get("id") is None,
+                record.get("id"),
+            ),
+        )
+
+    return records[0]
+
+
 async def verify_student_by_id(student_id: str, **params) -> bool:
     """Verify student exists - simplified version for internal use.
 
@@ -608,6 +654,10 @@ async def complete_profile_details_service(
     try:
         student_identifier = data.get("user_id") or data.get("student_id")
         identifier_type = "user_id" if data.get("user_id") else "student_id"
+        # `student_id` is only unique within an auth group, so an auth_group (when the
+        # caller supplies one) scopes this to the right student. `auth_group` is not in
+        # STUDENT_QUERY_PARAMS, so it is filtered out of the patch payload below.
+        auth_group = data.get("auth_group")
 
         logger.info(
             f"Completing profile details for student ({identifier_type}): {student_identifier}"
@@ -621,24 +671,34 @@ async def complete_profile_details_service(
 
         student_data = build_student_and_user_data(data)
 
+        # Scope by auth_group whenever the caller supplied one, on both branches. A real
+        # user_id is globally unique and needs no scoping, but callers have been known to
+        # put a student_id in the user_id slot, and this is a write path - scoping
+        # defensively stops a mislabelled identifier from patching another auth group's
+        # student record.
         if identifier_type == "user_id":
-            student_response = get_students(user_id=student_identifier)
+            student_response = get_students(
+                user_id=student_identifier, auth_group=auth_group
+            )
         else:
-            student_response = get_student_by_id(student_identifier)
+            student_response = get_student_by_id(
+                student_identifier, auth_group=auth_group
+            )
 
-        if (
-            not student_response
-            or not isinstance(student_response, list)
-            or len(student_response) == 0
-        ):
+        if not student_response:
             logger.error(
                 f"Student not found for {identifier_type}: {student_identifier}"
             )
             raise HTTPException(status_code=404, detail="Student not found")
 
-        # Safe access to first student
-        first_student = student_response[0]
-        if not isinstance(first_student, dict) or "id" not in first_student:
+        # This is a write path: resolve the target record explicitly rather than
+        # assuming the lookup returned exactly one student.
+        first_student = select_student_record(
+            student_response,
+            identifier=str(student_identifier),
+            auth_group=auth_group,
+        )
+        if not first_student or "id" not in first_student:
             logger.error(f"Invalid student data structure: {first_student}")
             raise HTTPException(status_code=500, detail="Invalid student data")
 


### PR DESCRIPTION
## Why

Follow-up to #90. db-service dropped the global `student_id` unique index in [db-service#649](https://github.com/avantifellows/db-service/pull/649) (`20260723180512_drop_global_student_id_unique_index`), so the same `student_id` **legitimately** resolves to one student record per auth group. That is the intended model, not dirty data.

#90 fixed the login/verify path. These are the remaining readers that still collapsed a multi-record lookup to `[0]`:

| Site | Risk |
|---|---|
| `services/form_service.py` — `get_student_fields_for_form` | reads the wrong auth group's profile into a form |
| `services/student_service.py` — `complete_profile_details_service` | **write path** — patches profile data onto the wrong auth group's student |
| `router/student.py` — `GET /student/` | could not be scoped by auth group *at all* |

Neither `GET /form-schema/student` nor `GET /student/` accepted `auth_group`, so callers had no way to disambiguate even when they knew the answer.

## What

- **`select_student_record(...)`** — resolves a multi-record lookup by lowest `id`, deliberately mirroring db-service's own tie-break (`order_by: [asc: s.id], limit: 1` in `Users.get_student_by_student_id_unscoped/1`) so the two services agree on which student a bare `student_id` refers to instead of disagreeing on ordering. Logs a warning whenever it has to disambiguate, so these cases are visible.
- **Thread `auth_group`** through `get_student_fields_for_form` and `complete_profile_details_service`, and accept it on `GET /form-schema/student` and `GET /student/` (plus `auth_group_id` on the latter, which db-service also resolves).
- **Scope on the `user_id` branch too.** A real `user_id` is globally unique and needs no scoping, but portal-frontend was putting a `student_id` into the `user_id` slot (fixed in [portal-frontend#181](https://github.com/avantifellows/portal-frontend/pull/181)). Since `complete_profile_details_service` is a write, defensive scoping stops a mislabelled identifier from patching another auth group's record.

`auth_group` is not in `STUDENT_QUERY_PARAMS`, so `build_student_and_user_data` already filters it out of the PATCH payload — it scopes the lookup without leaking into the write.

## Deliberately no hard failure on ambiguity

I considered raising 409 when a bare `student_id` matches 2+ records, and rejected it: db-service resolves unscoped lookups deterministically rather than erroring, so a 409 here would make portal-backend **stricter than the service beneath it** and break a documented contract. Matching db-service's behavior is the correct call.

## Verification

`select_student_record` against the real production ordering for `8979364564`:

```
empty      -> {}
single     -> {'id': 7}
dict       -> {'id': 9}
multi      -> {'id': 490965}   # lowest id, matches db-service asc: s.id
null id    -> {'id': 5}        # null ids sort last
non-dict   -> {'id': 3}        # junk filtered out
```

Production regression check — single-auth-group students resolve identically scoped or not:

```
student_id=08463409&auth_group=PunjabStudents -> [(503059, 513579)]
student_id=08463409                           -> [(503059, 513579)]
```

### End-to-end against production db-service

Ran the real FastAPI app in-process (`TestClient`, GETs only) pointed at prod db-service, so routers + services + db-service all execute:

```
GET /student?student_id=8979364564&auth_group=UttarakhandStudents -> [(519352, 529877)]
GET /student?student_id=8979364564&auth_group=AllIndiaStudents    -> [(490965, 500009)]
GET /student?student_id=8979364564                               -> both (legacy path unchanged)
GET /student?student_id=8979364564&auth_group_id=5               -> [(519352, 529877)]
```

Non-student regression checks, same run:

```
GET /teacher/verify?teacher_id=1    -> 200 {is_valid: false}   (teacher_service, untouched)
GET /candidate/verify?candidate_id=1 -> 200 {is_valid: false}  (candidate_service, untouched)
GET /student?student_id=1&bogus=x   -> 400 allowlist intact
```

All six `authTypes` permutations from the frontend's `authValidation.js` (ID / DOB / PH and combinations) still pass the `/student/verify` allowlist.

### Note: db-service fails *open* on an unknown auth_group name

`Users.resolve_auth_group_id_by_name/1` returns `nil` for an unresolvable name, and `maybe_scope_to_auth_group(query, nil)` then applies **no filter** — so a typo'd auth group silently returns every record rather than none. `select_student_record` detects this (it received >1 record despite being scoped) and logs:

```
2 student records matched 8979364564 even when scoped to auth_group NoSuchGroupXYZ
```

then resolves deterministically. That is why the warning distinguishes the scoped case from the unscoped one.

`black` and `flake8` pass via pre-commit. No behavior change for any current caller: every existing call site omits `auth_group`, which keeps the previous path.

## Pairs with

**[avantifellows/portal-frontend#181](https://github.com/avantifellows/portal-frontend/pull/181)** — forwards the auth group into `GET /student` and removes the `user_id ?? student_id` fallback. The backend accepts `auth_group` here; the frontend is what actually starts sending it. **Merge this one first** — the frontend change 400s without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
