### PR TITLE
Add API Gateway stage throttling (DoS ceiling) — GHSA-gr37-36h9-22wg

### DIFF
--- a/templates/prod.yaml
+++ b/templates/prod.yaml
@@ -53,6 +53,14 @@ Resources:
 
   Api:
     Type: AWS::Serverless::HttpApi
+    Properties:
+      # Global DoS ceiling only — set above the observed legitimate peak
+      # (~350 req/s sustained during large sign-in events) so real cohort
+      # surges are never throttled. Per-source enumeration is stopped by a
+      # WAF rate-based rule (see PR), not this limit.
+      DefaultRouteSettings:
+        ThrottlingRateLimit: 1000
+        ThrottlingBurstLimit: 2000
 
 Outputs:
   ApiUrl:

--- a/templates/staging.yaml
+++ b/templates/staging.yaml
@@ -53,6 +53,11 @@ Resources:
 
   Api:
     Type: AWS::Serverless::HttpApi
+    Properties:
+      # Global DoS ceiling only; staging sees no cohort surges. See prod.yaml.
+      DefaultRouteSettings:
+        ThrottlingRateLimit: 200
+        ThrottlingBurstLimit: 400
 
 Outputs:
   ApiUrl:


### PR DESCRIPTION
## What this is

A **DoS/flood ceiling** at API Gateway, as defense-in-depth for the unauthenticated-PII advisory. It is deliberately **not** the enumeration fix — see below.

## Why edge throttling, not app code

Deployment is `AWS::Serverless::HttpApi` + Mangum Lambda. In-process rate limiting can't share counters across concurrent Lambda instances or cold starts, so it's the wrong layer. Stage throttling runs at the edge before Lambda and is pure config.

## Limits (set from real traffic, not guesses)

A large sign-in event on **2026-07-24 sustained ~350 req/s** (minute-average, ~1 hour) of legitimate cohort session-entry + signup. So:

- **prod: 1000/s steady, 2000 burst** — ~3× above observed peak; a classroom surge is never throttled.
- **staging: 200/400** — no cohort surges there.

## Honest limitation

A global ceiling high enough to clear a 350 req/s classroom does **not** stop ID enumeration — an attacker staying under 1000/s scrapes the userbase freely. This PR only prevents one source from saturating the API.

The **actual** anti-enumeration controls are the sibling PRs:
1. Deleting the dead read routes (#92) — removes surface.
2. Authenticating + self-scoping the frontend-called reads (`/student`, `/teacher`, `/candidate`, `/school`) — removes the PII enumeration entirely.
3. If the `/*/verify` boolean-oracle still warrants it: a WAF rate-based rule keyed by source IP + URI (needs the API fronted by CloudFront — bigger change, hence separate).

## Verification

- `cfn-lint` + `sam validate` pass on both templates.
- Deploy workflows build these templates unchanged, no conflicting route-setting overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)